### PR TITLE
Clean up pyproject.toml to enable a strict/non-strict installation procedure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.10,<3.12"
 dependencies = [
      "pymatgen>=2024.9.17.1",
-     "atomate2[strict]==0.0.18",
+     "atomate2[strict]>=0.0.18",
      "ase==3.23.0",
      "matgl==1.1.3",
      "numpy==1.26.4",
@@ -63,7 +63,7 @@ docs = [
 
 ]
 strict = [
-     "pymatgen>=2024.8.9",
+     "pymatgen==2024.10.3", #?
      "atomate2[strict]==0.0.18",
      "matgl==1.1.3",
      "quippy-ase==0.9.14; python_version < '3.12'",
@@ -75,6 +75,8 @@ strict = [
      "typing",
      "dgl==2.1.0",
      "torchdata==0.7.1",
+     "nequip==0.6.1",
+     "hiphive==1.3.1",
 ]
 dev = ["pre-commit>=2.12.1"]
 tests = ["pytest", "pytest-mock", "pytest-split", "pytest-cov", "types-setuptools"]


### PR DESCRIPTION
Changed the pyproject.toml to have a strict installation procedure (including hiphive, nequip version numbers)