### PR TITLE
ignore type checking block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ exclude_lines = [
   "pragma: no cover",
   "def __repr__",
   "if self.debug:",
+  "if TYPE_CHECKING:",
   "if settings.DEBUG",
   "raise AssertionError",
   "raise NotImplementedError",


### PR DESCRIPTION
Improves overall coverage as lines without actual code will be excluded from report