### PR TITLE
Raise informative errors on missing non-python dependencies when invoked

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,8 +74,9 @@ RUN curl -fsSL https://download.lammps.org/tars/lammps.tar.gz -o /opt/lammps.tar
      && make install-python \
      && cmake --build . --target clean
 
-# Add LAMMPS to PATH
+# Add LAMMPS to PATH and Shared LAMMPS library to LD_LIBRARY_PATH
 ENV PATH="${PATH}:/root/.local/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/root/.local/lib"
 
 # Set the working directory
 WORKDIR /workspace

--- a/src/autoplex/data/rss/jobs.py
+++ b/src/autoplex/data/rss/jobs.py
@@ -75,7 +75,8 @@ class RandomizedStructure(Maker):
     @requires(
         which("buildcell"),
         "RSS flows requires the executable 'buildcell' to be in PATH. "
-        "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to install required dependencies and add them to PATH.",
+        "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to "
+        "install required dependencies and add them to PATH.",
     )
     @job
     def make(self):

--- a/src/autoplex/data/rss/jobs.py
+++ b/src/autoplex/data/rss/jobs.py
@@ -8,7 +8,9 @@ from dataclasses import dataclass
 from multiprocessing import Pool
 from pathlib import Path
 from subprocess import run
+from shutil import which
 from typing import TYPE_CHECKING
+from monty.dev import requires
 
 if TYPE_CHECKING:
     from pymatgen.core import Structure
@@ -69,6 +71,11 @@ class RandomizedStructure(Maker):
     fragment_file: str | None = None
     fragment_numbers: list[str] | None = None
 
+    @requires(
+        which("buildcell"),
+        "RSS flows requires the executable 'buildcell' to be in PATH. "
+        "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to install required dependencies and add them to PATH.",
+    )
     @job
     def make(self):
         """Maker to create random structures by buildcell."""

--- a/src/autoplex/data/rss/jobs.py
+++ b/src/autoplex/data/rss/jobs.py
@@ -75,8 +75,9 @@ class RandomizedStructure(Maker):
     @requires(
         which("buildcell"),
         "RSS flows requires the executable 'buildcell' to be in PATH. "
-        "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to "
-        "install required dependencies and add them to PATH.",
+        "Please follow the instructions in the README to install AIRSS library "
+        "and add it to PATH here:"
+        " https://autoatml.github.io/autoplex/user/index.html#enabling-rss-workflows",
     )
     @job
     def make(self):

--- a/src/autoplex/data/rss/jobs.py
+++ b/src/autoplex/data/rss/jobs.py
@@ -7,9 +7,10 @@ import re
 from dataclasses import dataclass
 from multiprocessing import Pool
 from pathlib import Path
-from subprocess import run
 from shutil import which
+from subprocess import run
 from typing import TYPE_CHECKING
+
 from monty.dev import requires
 
 if TYPE_CHECKING:

--- a/src/autoplex/data/rss/jobs.py
+++ b/src/autoplex/data/rss/jobs.py
@@ -75,8 +75,8 @@ class RandomizedStructure(Maker):
     @requires(
         which("buildcell"),
         "RSS flows requires the executable 'buildcell' to be in PATH. "
-        "Please follow the instructions in the README to install AIRSS library "
-        "and add it to PATH here:"
+        "Please follow the instructions in the autoplex documentation to install "
+        "the AIRSS library and add it to PATH. Link to the documentation:"
         " https://autoatml.github.io/autoplex/user/index.html#enabling-rss-workflows",
     )
     @job

--- a/src/autoplex/data/rss/utils.py
+++ b/src/autoplex/data/rss/utils.py
@@ -423,7 +423,7 @@ def process_rss(
             raise RuntimeError(
                 "To use RSS flow with J-ACE potential, it needs LAMMPS compiled with"
                 "python bindings and lammps-user-pace. Please follow the instructions in"
-                "the autoplex Documentation to install LAMMPS with the required packages here:"
+                "the autoplex documentation to install LAMMPS with the required packages here:"
                 " https://autoatml.github.io/autoplex/user/index.html#lammps-installation"
             ) from exc
 

--- a/src/autoplex/data/rss/utils.py
+++ b/src/autoplex/data/rss/utils.py
@@ -412,7 +412,7 @@ def process_rss(
 
             _ = lammps()
         except Exception as exc:
-            raise ImportError(
+            raise RuntimeError(
                 "To use RSS flow with J-ACE potential, it needs LAMMPS compiled with"
                 "python bindings and lammps-user-pace. Please follow the instructions in"
                 "the autoplex Documentation to install LAMMPS with the required packages."

--- a/src/autoplex/data/rss/utils.py
+++ b/src/autoplex/data/rss/utils.py
@@ -407,6 +407,16 @@ def process_rss(
     elif mlip_type == "J-ACE":
         from ase.calculators.lammpslib import LAMMPSlib
 
+        try:
+            pass
+        except Exception as exc:
+            raise ImportError(
+                "To use RSS flow with J-ACE potential, it needs LAMMPS compiled with"
+                "python bindings and lammps-user-pace. Please follow the instructions in"
+                "the autoplex Documentation to install LAMMPS with the required packages."
+                "https://autoatml.github.io/autoplex/user/index.html#lammps-installation"
+            ) from exc
+
         ace_label = os.path.join(mlip_path, "acemodel.yace")
         ace_json = os.path.join(mlip_path, "acemodel.json")
         ace_table = os.path.join(mlip_path, "acemodel_pairpot.table")

--- a/src/autoplex/data/rss/utils.py
+++ b/src/autoplex/data/rss/utils.py
@@ -408,7 +408,9 @@ def process_rss(
         from ase.calculators.lammpslib import LAMMPSlib
 
         try:
-            pass
+            from lammps import lammps
+
+            _ = lammps()
         except Exception as exc:
             raise ImportError(
                 "To use RSS flow with J-ACE potential, it needs LAMMPS compiled with"

--- a/src/autoplex/data/rss/utils.py
+++ b/src/autoplex/data/rss/utils.py
@@ -410,13 +410,21 @@ def process_rss(
         try:
             from lammps import lammps
 
-            _ = lammps()
+            lmp = lammps()
+            if "ML-PACE" not in lmp.installed_packages:
+                raise RuntimeError(
+                    "To use RSS flow with J-ACE potential, it needs LAMMPS compiled with"
+                    "lammps-user-pace library. ML-PACE is not found in the current LAMMPS binary installation."
+                    "Please follow the instructions in the autoplex Documentation to install"
+                    "LAMMPS with the required packages here:"
+                    " https://autoatml.github.io/autoplex/user/index.html#lammps-installation"
+                )
         except Exception as exc:
             raise RuntimeError(
                 "To use RSS flow with J-ACE potential, it needs LAMMPS compiled with"
                 "python bindings and lammps-user-pace. Please follow the instructions in"
-                "the autoplex Documentation to install LAMMPS with the required packages."
-                "https://autoatml.github.io/autoplex/user/index.html#lammps-installation"
+                "the autoplex Documentation to install LAMMPS with the required packages here:"
+                " https://autoatml.github.io/autoplex/user/index.html#lammps-installation"
             ) from exc
 
         ace_label = os.path.join(mlip_path, "acemodel.yace")

--- a/src/autoplex/data/rss/utils.py
+++ b/src/autoplex/data/rss/utils.py
@@ -415,15 +415,16 @@ def process_rss(
                 raise RuntimeError(
                     "To use RSS flow with J-ACE potential, it needs LAMMPS compiled with"
                     "lammps-user-pace library. ML-PACE is not found in the current LAMMPS binary installation."
-                    "Please follow the instructions in the autoplex Documentation to install"
-                    "LAMMPS with the required packages here:"
+                    "Please follow the instructions in the autoplex documentation to install"
+                    "LAMMPS with the required packages. Link to the documentation: "
                     " https://autoatml.github.io/autoplex/user/index.html#lammps-installation"
                 )
         except Exception as exc:
             raise RuntimeError(
                 "To use RSS flow with J-ACE potential, it needs LAMMPS compiled with"
                 "python bindings and lammps-user-pace. Please follow the instructions in"
-                "the autoplex documentation to install LAMMPS with the required packages here:"
+                "the autoplex documentation to install LAMMPS with the required packages. "
+                "Link to the documentation:"
                 " https://autoatml.github.io/autoplex/user/index.html#lammps-installation"
             ) from exc
 

--- a/src/autoplex/fitting/common/utils.py
+++ b/src/autoplex/fitting/common/utils.py
@@ -12,7 +12,6 @@ import sys
 import xml.etree.ElementTree as ET
 from functools import partial
 from pathlib import Path
-from shutil import which
 from typing import TYPE_CHECKING
 
 from monty.dev import requires
@@ -249,13 +248,6 @@ def gap_fitting(
     }
 
 
-@requires(
-    which("julia"),
-    "J-ACE fitting requires 'julia' and ACEPotentials.jl v0.6.7 library to be in PATH. "
-    "Please follow the instructions in the autoplex documentation to install the required julia dependencies "
-    "and add them to PATH. Link to the documentation:"
-    " https://autoatml.github.io/autoplex/user/index.html#standard-installation",
-)
 @requires(
     (
         subprocess.run(

--- a/src/autoplex/fitting/common/utils.py
+++ b/src/autoplex/fitting/common/utils.py
@@ -12,7 +12,9 @@ import sys
 import xml.etree.ElementTree as ET
 from functools import partial
 from pathlib import Path
+from shutil import which
 from typing import TYPE_CHECKING
+from monty.dev import requires
 
 if TYPE_CHECKING:
     from pymatgen.core import Structure
@@ -246,6 +248,11 @@ def gap_fitting(
     }
 
 
+@requires(
+        which("julia"),
+        "J-ACE fitting requires the executables 'julia' and ACEPotentials.jl library to be in PATH. "
+        "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to install required dependencies and add them to PATH.",
+    )
 def jace_fitting(
     db_dir: str | Path,
     path_to_default_hyperparameters: Path | str = MLIP_RSS_DEFAULTS_FILE_PATH,

--- a/src/autoplex/fitting/common/utils.py
+++ b/src/autoplex/fitting/common/utils.py
@@ -251,9 +251,27 @@ def gap_fitting(
 
 @requires(
     which("julia"),
-    "J-ACE fitting requires the executable 'julia' and ACEPotentials.jl library to be in PATH. "
-    "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to install "
-    "required dependencies and add them to PATH.",
+    "J-ACE fitting requires 'julia' and ACEPotentials.jl v0.6.7 library to be in PATH. "
+    "Please follow the instructions in the autoplex documentation to install the required julia dependencies "
+    "and add them to PATH. Link to the documentation:"
+    " https://autoatml.github.io/autoplex/user/index.html#standard-installation",
+)
+@requires(
+    (
+        subprocess.run(
+            'julia -e "using Pkg; println(haskey(Pkg.dependencies(), '
+            'Base.UUID(\\"3b96b61c-0fcc-4693-95ed-1ef9f35fcc53\\")))"',
+            shell=True,
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.strip()
+    )
+    == "true",
+    "J-ACE fitting requires the executable 'julia' and ACEPotentials.jl v0.6.7 library to be in PATH. "
+    "Please follow the instructions in the autoplex documentation to install the required julia dependencies "
+    "and add them to PATH. Link to the documentation:"
+    " https://autoatml.github.io/autoplex/user/index.html#standard-installation",
 )
 def jace_fitting(
     db_dir: str | Path,

--- a/src/autoplex/fitting/common/utils.py
+++ b/src/autoplex/fitting/common/utils.py
@@ -14,6 +14,7 @@ from functools import partial
 from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING
+
 from monty.dev import requires
 
 if TYPE_CHECKING:
@@ -249,10 +250,10 @@ def gap_fitting(
 
 
 @requires(
-        which("julia"),
-        "J-ACE fitting requires the executables 'julia' and ACEPotentials.jl library to be in PATH. "
-        "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to install required dependencies and add them to PATH.",
-    )
+    which("julia"),
+    "J-ACE fitting requires the executables 'julia' and ACEPotentials.jl library to be in PATH. "
+    "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to install required dependencies and add them to PATH.",
+)
 def jace_fitting(
     db_dir: str | Path,
     path_to_default_hyperparameters: Path | str = MLIP_RSS_DEFAULTS_FILE_PATH,

--- a/src/autoplex/fitting/common/utils.py
+++ b/src/autoplex/fitting/common/utils.py
@@ -251,8 +251,9 @@ def gap_fitting(
 
 @requires(
     which("julia"),
-    "J-ACE fitting requires the executables 'julia' and ACEPotentials.jl library to be in PATH. "
-    "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to install required dependencies and add them to PATH.",
+    "J-ACE fitting requires the executable 'julia' and ACEPotentials.jl library to be in PATH. "
+    "Please follow the instructions in the README (https://autoatml.github.io/autoplex/user/index.html) to install "
+    "required dependencies and add them to PATH.",
 )
 def jace_fitting(
     db_dir: str | Path,

--- a/tests/data/log.lammps
+++ b/tests/data/log.lammps
@@ -1,4 +1,0 @@
-LAMMPS (27 Jun 2024)
-OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
-  using 1 OpenMP thread(s) per MPI task
-Total wall time: 0:00:23


### PR DESCRIPTION
Closes #137 

## Changes

1. Added requires where possible
2. Added try except block to check lammps compilation
3. Minor update to docker file that only affects lammps usage directly via command line