### PR TITLE
Upgrade pypi release action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -69,7 +69,7 @@ jobs:
           pip install build
           python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1.10.3
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Issue
Currently, seems the issue seems twine package and version used in action uses older version of twine, leading to failures in metadata checks before upload to pypi , thus release fails.

https://github.com/pypi/warehouse/issues/15611

## Fix
Seems to be upgrading twine version, 
https://github.com/pypi/warehouse/issues/15611

Thus updating to latest pypi release action should fix it as it uses newer twine version, see here
https://github.com/pypa/gh-action-pypi-publish/issues/354#issuecomment-2814876458
https://github.com/ome/ome-zarr-py/pull/449
