### PR TITLE
Improve GAP fitting

### DIFF
--- a/src/autoplex/data/common/utils.py
+++ b/src/autoplex/data/common/utils.py
@@ -6,6 +6,7 @@ import random
 import shutil
 import warnings
 from collections.abc import Iterable
+from functools import partial
 from itertools import chain
 from multiprocessing import Pool
 from pathlib import Path
@@ -26,6 +27,7 @@ from pymatgen.io.ase import AseAtomsAdaptor
 from quippy import descriptors
 from scipy.sparse.linalg import LinearOperator, svds
 from sklearn.model_selection import StratifiedShuffleSplit
+from threadpoolctl import threadpool_limits
 
 from autoplex.fitting.common.regularization import (
     calculate_hull_nd,
@@ -986,13 +988,10 @@ def cur_select(
 
     num_workers = min(len(fatoms), os.cpu_count() or 1)
 
-    with Pool(
-        processes=num_workers
-    ) as pool:  # TODO: implement argument for number of cores throughout
-        ats = pool.starmap(
-            parallel_calc_descriptor_vec,
-            [(atom, selected_descriptor) for atom in fatoms],
-        )
+    worker = partial(parallel_calc_descriptor_vec, selected_descriptor)
+    with threadpool_limits(limits=1), Pool(processes=num_workers) as pool:
+        # TODO: implement argument for number of cores throughout
+        ats = pool.map(worker, fatoms)
 
     if isinstance(ats, list) & (len(ats) != 0):
         at_descs = np.array([at.info["descriptor_vec"] for at in ats]).T

--- a/src/autoplex/data/common/utils.py
+++ b/src/autoplex/data/common/utils.py
@@ -988,7 +988,9 @@ def cur_select(
 
     num_workers = min(len(fatoms), os.cpu_count() or 1)
 
-    worker = partial(parallel_calc_descriptor_vec, selected_descriptor)
+    worker = partial(
+        parallel_calc_descriptor_vec, selected_descriptor=selected_descriptor
+    )
     with threadpool_limits(limits=1), Pool(processes=num_workers) as pool:
         # TODO: implement argument for number of cores throughout
         ats = pool.map(worker, fatoms)

--- a/src/autoplex/data/common/utils.py
+++ b/src/autoplex/data/common/utils.py
@@ -988,12 +988,12 @@ def cur_select(
 
     num_workers = min(len(fatoms), os.cpu_count() or 1)
 
-    worker = partial(
+    descriptor_worker = partial(
         parallel_calc_descriptor_vec, selected_descriptor=selected_descriptor
     )
     with threadpool_limits(limits=1), Pool(processes=num_workers) as pool:
         # TODO: implement argument for number of cores throughout
-        ats = pool.map(worker, fatoms)
+        ats = pool.map(descriptor_worker, fatoms)
 
     if isinstance(ats, list) & (len(ats) != 0):
         at_descs = np.array([at.info["descriptor_vec"] for at in ats]).T

--- a/src/autoplex/data/rss/utils.py
+++ b/src/autoplex/data/rss/utils.py
@@ -3,6 +3,7 @@
 import ast
 import json
 import os
+from functools import partial
 from multiprocessing import Pool
 from pathlib import Path
 from typing import Literal
@@ -26,6 +27,7 @@ from matgl.ext.ase import M3GNetCalculator
 from nequip.ase import NequIPCalculator
 from pymatgen.core import Structure
 from pymatgen.io.ase import AseAtomsAdaptor
+from threadpoolctl import threadpool_limits
 
 from autoplex.fitting.common.utils import (
     CustomPotential,
@@ -625,33 +627,30 @@ def minimize_structures(
     for i, atom in enumerate(atoms):
         atom.info["unique_starting_index"] = iteration_index + f"{i+struct_start_index}"
 
-    args = [
-        (
-            atom,
-            mlip_type,
-            mlip_path,
-            output_file_name,
-            scalar_pressure_method,
-            scalar_exp_pressure,
-            scalar_pressure_exponential_width,
-            scalar_pressure_low,
-            scalar_pressure_high,
-            max_steps,
-            force_tol,
-            stress_tol,
-            hookean_repul,
-            hookean_paras,
-            write_traj,
-            device,
-            isolated_atom_energies,
-            config_type,
-            keep_symmetry,
-        )
-        for atom in atoms
-    ]
+    worker = partial(
+        process_rss,
+        mlip_type=mlip_type,
+        mlip_path=mlip_path,
+        output_file_name=output_file_name,
+        scalar_pressure_method=scalar_pressure_method,
+        scalar_exp_pressure=scalar_exp_pressure,
+        scalar_pressure_exponential_width=scalar_pressure_exponential_width,
+        scalar_pressure_low=scalar_pressure_low,
+        scalar_pressure_high=scalar_pressure_high,
+        max_steps=max_steps,
+        force_tol=force_tol,
+        stress_tol=stress_tol,
+        hookean_repul=hookean_repul,
+        hookean_paras=hookean_paras,
+        write_traj=write_traj,
+        device=device,
+        isolated_atom_energies=isolated_atom_energies,
+        config_type=config_type,
+        keep_symmetry=keep_symmetry,
+    )
 
-    with Pool(processes=num_processes_rss) as pool:
-        results = pool.starmap(process_rss, args)
+    with threadpool_limits(limits=1), Pool(processes=num_processes_rss) as pool:
+        results = pool.map(worker, atoms)
 
     return list(results)
 

--- a/src/autoplex/data/rss/utils.py
+++ b/src/autoplex/data/rss/utils.py
@@ -10,7 +10,6 @@ from typing import Literal
 import ase.io
 import matgl
 import numpy as np
-import quippy.potential
 from ase import Atoms
 from ase.constraints import (
     FixConstraint,
@@ -28,25 +27,10 @@ from nequip.ase import NequIPCalculator
 from pymatgen.core import Structure
 from pymatgen.io.ase import AseAtomsAdaptor
 
-from autoplex.fitting.common.utils import extract_gap_label
-
-
-class CustomPotential(quippy.potential.Potential):
-    """A custom potential class that modifies the outputs of potentials."""
-
-    def calculate(self, *args, **kwargs):
-        """Update the atoms object with forces, energy, and virial information."""
-        res = super().calculate(*args, **kwargs)
-        atoms = kwargs["atoms"] if "atoms" in kwargs else args[0]
-        if "forces" in self.results:
-            atoms.arrays["forces"] = self.results["forces"].copy()
-        if "energy" in self.results:
-            atoms.info["energy"] = self.results["energy"].copy()
-        if "stress" in self.results:
-            atoms.info["stress"] = self.results["stress"].copy()
-        if "virial" in self.extra_results["config"]:
-            atoms.info["virial"] = self.extra_results["config"]["virial"].copy()
-        return res
+from autoplex.fitting.common.utils import (
+    CustomPotential,
+    extract_gap_label,
+)
 
 
 def extract_pairstyle(

--- a/src/autoplex/data/rss/utils.py
+++ b/src/autoplex/data/rss/utils.py
@@ -627,7 +627,7 @@ def minimize_structures(
     for i, atom in enumerate(atoms):
         atom.info["unique_starting_index"] = iteration_index + f"{i+struct_start_index}"
 
-    worker = partial(
+    minimize_worker = partial(
         process_rss,
         mlip_type=mlip_type,
         mlip_path=mlip_path,
@@ -650,7 +650,7 @@ def minimize_structures(
     )
 
     with threadpool_limits(limits=1), Pool(processes=num_processes_rss) as pool:
-        results = pool.map(worker, atoms)
+        results = pool.map(minimize_worker, atoms)
 
     return list(results)
 

--- a/src/autoplex/fitting/common/utils.py
+++ b/src/autoplex/fitting/common/utils.py
@@ -1830,7 +1830,7 @@ def calculate_delta_2b(
 
 def compute_num_of_descriptor(atom: Atoms, nb: int, cutoff: float) -> list[float]:
     """
-    Calculate the number of pairwise and triplet within a cutoff distance for a given list of atoms.
+    Compute the number of two-body or three-body descriptors within a specified cutoff radius.
 
     Parameters
     ----------
@@ -1968,9 +1968,11 @@ def run_ase_gap(
     """
     gap_control = "Potential xml_label=" + extract_gap_label(xml_file)
     atoms = ase.io.read(data_path, index=":")
-    worker = partial(_compute_gap_energy, gap_control=gap_control, gap_label=xml_file)
+    eval_worker = partial(
+        _compute_gap_energy, gap_control=gap_control, gap_label=xml_file
+    )
     with threadpool_limits(limits=1), mp.Pool(processes=num_processes_fit) as pool:
-        atoms_eval = pool.map(worker, atoms)
+        atoms_eval = pool.map(eval_worker, atoms)
     ase.io.write(filename, atoms_eval, format="extxyz")
 
 

--- a/tests/fitting/common/test_jobs.py
+++ b/tests/fitting/common/test_jobs.py
@@ -6,7 +6,30 @@ from jobflow import run_locally
 from tests.auto.phonons.test_jobs import fake_run_vasp_kwargs
 
 
-def test_gap_fit_maker(test_dir, memory_jobstore, clean_dir):
+def test_gap_auto_delta_fit_maker(test_dir, memory_jobstore, clean_dir):
+
+    database_dir = test_dir / "fitting/rss_training_dataset/"
+
+    gapfit = MLIPFitMaker(
+        auto_delta=True,
+        glue_xml=False,
+        apply_data_preprocessing=False,
+    ).make(
+        twob={"delta": 2.0, "cutoff": 4},
+        threeb={"n_sparse": 10},
+        database_dir=database_dir,
+        general={"two_body": True,
+                 "three_body": True}
+        )
+
+    _ = run_locally(
+        gapfit, ensure_success=True, create_folders=True, store=memory_jobstore
+    )
+
+    assert Path(gapfit.output["mlip_path"][0].resolve(memory_jobstore)).exists()
+    
+    
+def test_gap_fixed_delta_fit_maker(test_dir, memory_jobstore, clean_dir):
 
     database_dir = test_dir / "fitting/rss_training_dataset/"
 
@@ -16,8 +39,10 @@ def test_gap_fit_maker(test_dir, memory_jobstore, clean_dir):
         apply_data_preprocessing=False,
     ).make(
         twob={"delta": 2.0, "cutoff": 4},
-        threeb={"n_sparse": 10},
-        database_dir=database_dir
+        threeb={"delta": 1.5, "n_sparse": 10},
+        database_dir=database_dir,
+        general={"two_body": True,
+                 "three_body": True}
         )
 
     _ = run_locally(


### PR DESCRIPTION
This PR makes the GAP‐fitting module more robust by replacing `quip` with the ASE calculator. It also parallelizes computations using multiprocessing where possible. New relevant unit tests are added. 

It also improves computational efficiency: when `auto_delta=False`, fitting is done only once, whereas previously the code would run multiple fits if more than two descriptors were included.