### PR TITLE
Add .gitattributes to mark tests as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-tests/** linguist-vendored
+tests/test_data/** linguist-vendored


### PR DESCRIPTION
This pull request makes a minor configuration update to the `.gitattributes` file to improve repository management.

- Repository configuration:
  * Marked all files under the `tests/` directory as `linguist-vendored`, which will exclude them from language statistics and code search on GitHub.