### PR TITLE
include pacemaker test-durations and coverage 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -69,9 +69,30 @@ jobs:
         include-hidden-files: true
         path: ./.coverage
 
-  commit-durations:
-    if: github.repository_owner == 'autoatml' && github.ref == 'refs/heads/main'
+  get-pacemaker-run:
     needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      run_id: ${{ steps.get-run.outputs.run_id }}
+    steps:
+      - name: Get latest successful Pacemaker run ID
+        id: get-run
+        run: |
+          RUN_ID=$(gh run list \
+            --repo ${{ github.repository }} \
+            --workflow="Testing Pacemaker (Python 3.10)" \
+            --branch=main \
+            --status=success \
+            --limit=1 \
+            --json databaseId \
+            -q '.[0].databaseId')
+          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  commit-durations:
+    # if: github.repository_owner == 'autoatml' && github.ref == 'refs/heads/main'
+    needs: [build, get-pacemaker-run]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -102,6 +123,14 @@ jobs:
       with:
         pattern: test-durations-*
 
+    - name: Download Pacemaker test duration artifacts
+      continue-on-error: true
+      uses: actions/download-artifact@v4
+      with:
+        pattern: test-durations-pacemaker
+        run-id: ${{ needs.get-pacemaker-run.outputs.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
 
     - name: Compute average of test durations
       run: |
@@ -123,10 +152,10 @@ jobs:
         base: main
 
   coverage:
-      needs: build
+      needs: [build, get-pacemaker-run]
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Set up Python 3.10
           uses: actions/setup-python@v4
           with:
@@ -134,11 +163,19 @@ jobs:
         - name: Install Coverage
           run: |
            python -m pip install coverage[toml]
+
         - name: Download coverage artifacts
           continue-on-error: true
           uses: actions/download-artifact@v4
           with:
             pattern: coverage-*
+        - name: Download Pacemaker coverage artifacts
+          continue-on-error: true
+          uses: actions/download-artifact@v4
+          with:
+            pattern: coverage-pacemaker
+            run-id: ${{ needs.get-pacemaker-run.outputs.run_id }}
+            github-token: ${{ secrets.GITHUB_TOKEN }}
         - name: Run coverage
           continue-on-error: true
           run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -91,7 +91,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   commit-durations:
-    # if: github.repository_owner == 'autoatml' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'autoatml' && github.ref == 'refs/heads/main'
     needs: [build, get-pacemaker-run]
     runs-on: ubuntu-latest
     defaults:
@@ -131,7 +131,6 @@ jobs:
         run-id: ${{ needs.get-pacemaker-run.outputs.run_id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-
     - name: Compute average of test durations
       run: |
         micromamba activate autoplex_tests
@@ -160,6 +159,7 @@ jobs:
           uses: actions/setup-python@v4
           with:
             python-version: '3.10'
+
         - name: Install Coverage
           run: |
            python -m pip install coverage[toml]
@@ -169,6 +169,7 @@ jobs:
           uses: actions/download-artifact@v4
           with:
             pattern: coverage-*
+
         - name: Download Pacemaker coverage artifacts
           continue-on-error: true
           uses: actions/download-artifact@v4
@@ -176,6 +177,7 @@ jobs:
             pattern: coverage-pacemaker
             run-id: ${{ needs.get-pacemaker-run.outputs.run_id }}
             github-token: ${{ secrets.GITHUB_TOKEN }}
+
         - name: Run coverage
           continue-on-error: true
           run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the Python package to improve artifact handling and integrate results from the Pacemaker workflow. The main changes introduce a new job to fetch the latest successful Pacemaker run, update dependencies between jobs, and ensure both test duration and coverage artifacts from Pacemaker are downloaded and used in subsequent steps.

**Workflow orchestration improvements:**

* Added a new `get-pacemaker-run` job to retrieve the latest successful Pacemaker workflow run ID using the GitHub CLI, and made both `commit-durations` and `coverage` jobs depend on it

**Artifact handling enhancements:**

* Updated the `commit-durations` and `coverage` jobs to download Pacemaker test duration and coverage artifacts, respectively, using the retrieved run ID. This ensures that data from the Pacemaker workflow is incorporated into metrics calculations.
