### PR TITLE
fixed fragment list error and added test

### DIFF
--- a/src/autoplex/data/rss/jobs.py
+++ b/src/autoplex/data/rss/jobs.py
@@ -180,6 +180,8 @@ class RandomizedStructure(Maker):
                         self.fragment.arrays["fragment_id"] = [
                             f"{1}-f" for i in self.fragment
                         ]
+                    symbols = [self.fragment.get_chemical_symbols()]
+                    self.fragment = [self.fragment]
 
                 elif isinstance(self.fragment, list):
                     if self.fragment_numbers is None:
@@ -188,29 +190,25 @@ class RandomizedStructure(Maker):
                         ]
                     else:
                         fragment_numbers = self.fragment_numbers
-                    write_fragment = self.fragment[0]
-                    for frag in self.fragment[
-                        1:
-                    ]:  # merge all separate fragments into one Atoms object
-                        write_fragment += frag
+                    symbols = [i.get_chemical_symbols() for i in self.fragment]
 
                 fragment_parameters = [
                     "%BLOCK POSITIONS_ABS",
                 ]
-                symbols = self.fragment.get_chemical_symbols()
-                for i, val in enumerate(self.fragment.get_positions(wrap=True)):
-                    if i == 0:
-                        newline = (
-                            f"{symbols[i]} {val[0]:.8f} {val[1]:.8f} {val[2]:.8f}"
-                            f" # {self.fragment.arrays['fragment_id'][i]}"
-                            f" % NUM={fragment_numbers[i]}"
-                        )
-                    else:
-                        newline = (
-                            f"{symbols[i]} {val[0]:.8f} {val[1]:.8f} {val[2]:.8f}"
-                            f" # {self.fragment.arrays['fragment_id'][i]}"
-                        )
-                    fragment_parameters.append(newline)
+                for ifrag, frag in enumerate(self.fragment):
+                    for i, val in enumerate(frag.get_positions(wrap=True)):
+                        if i == 0:
+                            newline = (
+                                f"{symbols[ifrag][i]} {val[0]:.8f} {val[1]:.8f} {val[2]:.8f}"
+                                f" # frag-{ifrag}"
+                                f" % NUM={fragment_numbers[ifrag]}"
+                            )
+                        else:
+                            newline = (
+                                f"{symbols[ifrag][i]} {val[0]:.8f} {val[1]:.8f} {val[2]:.8f}"
+                                f" # frag-{ifrag}"  # atoms with same # frag-tag stay together during rss
+                            )
+                        fragment_parameters.append(newline)
                 fragment_parameters.append("%ENDBLOCK POSITIONS_ABS")
 
                 buildcell_parameters = (

--- a/tests/data/rss/test_jobs.py
+++ b/tests/data/rss/test_jobs.py
@@ -479,7 +479,7 @@ def test_fragment_buildcell(test_dir, memory_jobstore, clean_dir):
     assert len(ats) == 4 and np.all(ats[0].positions[0] != ats[0].positions[1])
 
 
-def test_fragment_buildcell_multifrags(test_dir, memory_jobstore):
+def test_fragment_buildcell_multifrags(test_dir, memory_jobstore, clean_dir):
     from ase.io import read
     import numpy as np
     from ase import Atoms

--- a/tests/data/rss/test_jobs.py
+++ b/tests/data/rss/test_jobs.py
@@ -479,6 +479,43 @@ def test_fragment_buildcell(test_dir, memory_jobstore, clean_dir):
     assert len(ats) == 4 and np.all(ats[0].positions[0] != ats[0].positions[1])
 
 
+def test_fragment_buildcell_multifrags(test_dir, memory_jobstore):
+    from ase.io import read
+    import numpy as np
+    from ase import Atoms
+    from ase.io import write
+   
+    Li=Atoms('Li') 
+    PS4=Atoms('PS4', positions=
+    [[    0.00941764  ,    -0.00341252  ,    -0.03256453],
+    [    -1.66997738  ,     0.96618661  ,     0.65304559],
+    [     0.00941761  ,    -0.00341254  ,    -2.08939495],
+    [     0.00941761  ,    -1.94261084  ,     0.65304559],
+    [     1.68881260  ,     0.96618661  ,     0.65304559], 
+    ])
+    frags=[Li, PS4]
+
+    os.system(f'rm {test_dir}/data/fragments.extxyz')
+    for frag in frags:
+        frag.write(f'{test_dir}/data/fragments.extxyz', append=True)
+    
+    job_rss = RandomizedStructure(struct_number=4,
+                                  tag='LiPS',
+                                  output_file_name='random_LPS_structs.extxyz',
+                                  buildcell_option={'TARGVOL':'20-200',
+                                                    'NFORM': '{1,2,3,4}',
+                                                    'MINSEP': '2 P-P=5.0-7.0',
+                                                    },
+                                  fragment_file=os.path.join(f'{test_dir}/data/', 'fragments.extxyz'),
+                                  fragment_numbers=[3,1],
+                                  remove_tmp_files=False,
+                                  num_processes=4).make()
+    
+    run_locally(job_rss, ensure_success=True, create_folders=True, store=memory_jobstore)
+    ats = read(job_rss.output.resolve(memory_jobstore), index=":")
+    assert len(ats) == 4 and np.all(ats[0].positions[0] != ats[0].positions[1])
+
+
 def test_output_from_cell_seed(test_dir, memory_jobstore, clean_dir):
     from ase.io import read
     test_files_dir = test_dir / "data/SiO2.cell"

--- a/tests/data/rss/test_jobs.py
+++ b/tests/data/rss/test_jobs.py
@@ -495,7 +495,6 @@ def test_fragment_buildcell_multifrags(test_dir, memory_jobstore, clean_dir):
     ])
     frags=[Li, PS4]
 
-    os.system(f'rm {test_dir}/data/fragments.extxyz')
     for frag in frags:
         frag.write(f'{test_dir}/data/fragments.extxyz', append=True)
     


### PR DESCRIPTION
The RSS workflow failed for me when I provided a fragments file containing more than one image (I needed this because LPS has PS4 tetrahedra that I would like to keep intact during the sampling). I edited the code so that providing multiple images as fragments works now as well.