### PR TITLE
fix scikit-build-core version for the phonopy wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
      "hiphive",
      "quippy-ase==0.9.14; python_version < '3.12'",
      "f90wrap==0.2.16",
-     "scikit-build-core<0.10",
+     "scikit-build-core==1.0.2",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
      "typing",
      "hiphive",
      "quippy-ase==0.9.14; python_version < '3.12'",
-     "f90wrap==0.2.16"
+     "f90wrap==0.2.16",
+     "scikit-build-core<0.10",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Fixed the scikit-build-core version to fix the build of the phonopy wheel