### PR TITLE
pin scikit-build-core and update docs workflows > fix phonopy older build failures

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
             micromamba activate autoplex_docs
             uv pip install --upgrade pip
+            uv pip install "scikit-build-core<0.10"
+            uv pip install setuptools-scm>=8.0 nanobind
+            uv pip install --no-build-isolation phonopy==2.30.1
             uv pip install --prerelease=allow .[docs,strict,tests]
             uv pip install --upgrade monty
             uv pip install numpy==1.26.4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -206,6 +206,7 @@ jobs:
       - name: Install autoplex and dependencies
         run: |
             micromamba activate autoplex_docs
+            uv pip install --upgrade pip
             uv pip install "scikit-build-core<0.10"
             uv pip install setuptools-scm>=8.0 nanobind
             uv pip install --no-build-isolation phonopy==2.30.1

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -207,6 +207,8 @@ jobs:
         run: |
             micromamba activate autoplex_docs
             uv pip install --upgrade pip
+            uv pip install setuptools-scm>=8.0 nanobind
+            uv pip install --no-build-isolation phonopy==2.30.1
             uv pip install --prerelease=allow .[docs,strict_all,tests,aims]
 
       - name: Copy tutorials

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Install autoplex and dependencies
         run: |
             micromamba activate autoplex_docs
-            uv pip install --upgrade pip
+            uv pip install "scikit-build-core<0.10"
             uv pip install setuptools-scm>=8.0 nanobind
             uv pip install --no-build-isolation phonopy==2.30.1
             uv pip install --prerelease=allow .[docs,strict_all,tests,aims]

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,5 +84,8 @@ COPY . /workspace
 RUN python -m pip install --upgrade pip \
  && pip install uv \
  && uv pip install --system pre-commit pytest pytest-mock pytest-split pytest-cov types-setuptools \
+ && uv pip install --system "scikit-build-core<0.10" \
+ && uv pip install --system setuptools-scm>=8.0 nanobind \
+ && uv pip install --system --no-build-isolation "phonopy==2.30.1" \
  && uv pip install --system --prerelease=allow ".[strict,docs]" \
  && uv cache clean && rm -rf /tmp/*

--- a/README.md
+++ b/README.md
@@ -70,7 +70,15 @@ Before the installation, please make sure that you are using one of the supporte
 
 ## Standard installation
 
-You can install `autoplex` simply by:
+`phonopy` is normally installed automatically as a dependency through `atomate2`. However, build failures with newer `scikit-build-core` versions may prevent this. To avoid installation issues, install the `phonopy` build dependencies and `phonopy` separately before installing this package. Use the following commands:
+
+```
+pip install "scikit-build-core<0.10"
+pip install setuptools-scm nanobind
+pip install --no-build-isolation phonopy==2.30.1
+```
+
+Once this is done, you can install `autoplex` simply by:
 
 ```
 pip install autoplex[strict]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Before the installation, please make sure that you are using one of the supporte
 
 ```
 pip install "scikit-build-core<0.10"
-pip install setuptools-scm nanobind
+pip install setuptools-scm>=8.0 nanobind
 pip install --no-build-isolation phonopy==2.30.1
 ```
 

--- a/docs/dev/dev_install.md
+++ b/docs/dev/dev_install.md
@@ -5,6 +5,9 @@ Install autoplex from source, by cloning the repository via [github](https://git
 ```bash
 git clone https://github.com/autoatml/autoplex.git
 cd autoplex
+pip install "scikit-build-core<0.10"
+pip install setuptools-scm nanobind
+pip install --no-build-isolation phonopy==2.30.1
 pip install -e .[strict_all,dev,tests,docs]
 ```
 This will install autoplex will all dependencies for tests, pre-commit and docs building. 

--- a/docs/dev/dev_install.md
+++ b/docs/dev/dev_install.md
@@ -6,10 +6,11 @@ Install autoplex from source, by cloning the repository via [github](https://git
 git clone https://github.com/autoatml/autoplex.git
 cd autoplex
 pip install "scikit-build-core<0.10"
-pip install setuptools-scm nanobind
+pip install setuptools-scm>=8.0 nanobind
 pip install --no-build-isolation phonopy==2.30.1
 pip install -e .[strict_all,dev,tests,docs]
 ```
+
 This will install autoplex will all dependencies for tests, pre-commit and docs building. 
 However, note that non-python programs like `buildcell`, `lammps` and `julia` needed for ACE potential fitting 
 will not be installed with above command. One needs to install these separately. 

--- a/docs/user/installation/installation.md
+++ b/docs/user/installation/installation.md
@@ -45,7 +45,7 @@ When you have completed all these preparation steps, it's time to install `autop
 
 ```
 pip install "scikit-build-core<0.10"
-pip install setuptools-scm nanobind
+pip install setuptools-scm>=8.0 nanobind
 pip install --no-build-isolation phonopy==2.30.1
 ```
 

--- a/docs/user/installation/installation.md
+++ b/docs/user/installation/installation.md
@@ -39,7 +39,17 @@ Please take your time and check out all the documentation and tutorials!
 
 When you have completed all these preparation steps, it's time to install `autoplex`!
 
-You can install `autoplex` simply by:
+------------------------------------------
+
+`phonopy` is normally installed automatically as a dependency through `atomate2`. However, build failures with newer `scikit-build-core` versions may prevent this. To avoid installation issues, install the `phonopy` build dependencies and `phonopy` separately before installing this package. Use the following commands:
+
+```
+pip install "scikit-build-core<0.10"
+pip install setuptools-scm nanobind
+pip install --no-build-isolation phonopy==2.30.1
+```
+
+Once this is done, you can install `autoplex` simply by:
 
 ``` 
 pip install autoplex[strict]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ workflow-managers = [
     "jobflow-remote==0.1.7"
 ]
 strict_all = [
-     "scikit-build-core<0.10",
      "calorine==3.0",
      "pymatgen==2025.2.18",
      "atomate2[strict]==0.0.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ workflow-managers = [
     "jobflow-remote==0.1.7"
 ]
 strict_all = [
+     "scikit-build-core<0.10",
      "calorine==3.0",
      "pymatgen==2025.2.18",
      "atomate2[strict]==0.0.21",


### PR DESCRIPTION
# Changes

- Pre-install phonopy build dependencies compatible with the older phonopy version used by atomate2 0.0.21, i.e., v2.30.1 (scikit-build-core<0.10, nanobind, and setup-scm)
- Install phonopy with no-build-isolation in CI workflows and dockerfile to force installations of phonopy to use pre-installed dependencies.