### PR TITLE
update commit durations step of ci workflow

### DIFF
--- a/.github/workflows/python-base.yml
+++ b/.github/workflows/python-base.yml
@@ -169,8 +169,9 @@ jobs:
           uv pip install "scikit-build-core<0.10"
           uv pip install "setuptools-scm>=8.0" nanobind
           uv pip install --no-build-isolation phonopy==2.30.1
-          uv pip install .[docs,strict-base]
-          
+          uv pip install .[docs,strict-base,strict-mace,strict-matgl,strict-nep,strict-nequip,pacemaker,tests,aims]
+          uv pip install 'dgl==2.4.0' -f 'https://data.dgl.ai/wheels/torch-2.4/repo.html'
+                    
     - name: Download test duration artifacts
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
# Changes

- Automated updates of the test durations file step silently failed due to missing dependencies resulting from recent changes 